### PR TITLE
Define domain models aligned with OpenAPI spec #3

### DIFF
--- a/internal/api/dto.go
+++ b/internal/api/dto.go
@@ -1,0 +1,39 @@
+package api
+
+// These types are 1:1 with the given OpenAPI schemas
+
+// ProductDTO matches components.schemas.Product exactly.
+type ProductDTO struct {
+	ID       string  `json:"id"`
+	Name     string  `json:"name"`
+	Price    float64 `json:"price"`
+	Category string  `json:"category"`
+}
+
+// OrderItemDTO is the inline object used in Order and OrderReq
+type OrderItemDTO struct {
+	ProductID string `json:"productId"`
+	Quantity  int    `json:"quantity"`
+}
+
+// OrderReqDTO matches components.schema.OrderReq
+// Used for POST /order request bodies
+type OrderReqDTO struct {
+	CouponCode *string        `json:"couponCode,omitempty"`
+	Items      []OrderItemDTO `json:"items"`
+}
+
+// OrderDTO matches components.schemas.Order
+// used for responses from POST /order (and potentially GET /order in future)
+type OrderDTO struct {
+	ID       string         `json:"id"`
+	Items    []OrderItemDTO `json:"items"`
+	Products []ProductDTO   `json:"products"`
+}
+
+// ApiResponseDTO matches components.schemas.ApiResponse
+type ApiResponseDTO struct {
+	Code    int    `json:"code"`
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}

--- a/internal/api/mappers.go
+++ b/internal/api/mappers.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/M-Arthur/order-food-api/internal/domain"
+)
+
+// MapOrderReqToDomain builds a domain.Order from the incoming OrderReqDTO.
+func MapOrderReqToDomain(orderID domain.OrderID, req OrderReqDTO) (*domain.Order, error) {
+	items := make([]domain.OrderItem, 0, len(req.Items))
+
+	for i, item := range req.Items {
+		if item.ProductID == "" {
+			return nil, fmt.Errorf("items[%d].productId: required", i)
+		}
+		if item.Quantity < 1 {
+			return nil, fmt.Errorf("items[%d].quantity: must be >= 1", i)
+		}
+
+		items = append(items, domain.OrderItem{
+			ProductID: domain.ProductID(item.ProductID),
+			Quantity:  item.Quantity,
+		})
+	}
+
+	return domain.NewOrder(orderID, items, req.CouponCode)
+}
+
+// MapDomainProductToDTO converts a domain.Product to the API representation
+func MapDomainProductToDTO(p domain.Product) ProductDTO {
+	return ProductDTO{
+		ID:       string(p.ID),
+		Name:     p.Name,
+		Price:    p.Price.ToFloat(),
+		Category: p.Category,
+	}
+}
+
+func MapDomainProductsToDTO(products []domain.Product) []ProductDTO {
+	out := make([]ProductDTO, 0, len(products))
+	for _, p := range products {
+		out = append(out, MapDomainProductToDTO(p))
+	}
+	return out
+}
+
+// MapDomainOrderToDTO converts a domain.Order plus a set of products
+// into the OpenAPI Order shape.
+func MapDomainOrderToDTO(order *domain.Order, products []domain.Product) OrderDTO {
+	itemDTOs := make([]OrderItemDTO, 0, len(order.Items))
+	for _, item := range order.Items {
+		itemDTOs = append(itemDTOs, OrderItemDTO{
+			ProductID: string(item.ProductID),
+			Quantity:  item.Quantity,
+		})
+	}
+
+	return OrderDTO{
+		ID:       string(order.ID),
+		Items:    itemDTOs,
+		Products: MapDomainProductsToDTO(products),
+	}
+}

--- a/internal/api/mappers_test.go
+++ b/internal/api/mappers_test.go
@@ -1,0 +1,171 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/M-Arthur/order-food-api/internal/api"
+	"github.com/M-Arthur/order-food-api/internal/domain"
+)
+
+func TestMapOrderReqToDomain_Succes(t *testing.T) {
+	req := api.OrderReqDTO{
+		CouponCode: ptr("PROMO10"),
+		Items: []api.OrderItemDTO{
+			{ProductID: "p1", Quantity: 2},
+			{ProductID: "p2", Quantity: 1},
+		},
+	}
+
+	orderID := domain.OrderID("order-123")
+
+	order, err := api.MapOrderReqToDomain(orderID, req)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if orderID != order.ID {
+		t.Fatalf("order.ID = %s, want %s", order.ID, orderID)
+	}
+
+	if len(order.Items) != len(req.Items) {
+		t.Fatalf("order.Items len = %d, want %d", len(order.Items), len(req.Items))
+	}
+
+	if order.CouponCode == nil || *order.CouponCode != *req.CouponCode {
+		t.Fatalf("order.CouponCode = %v, want %s", order.CouponCode, *req.CouponCode)
+	}
+
+	for i, item := range order.Items {
+		want := req.Items[i]
+		if string(item.ProductID) != want.ProductID {
+			t.Errorf("item[%d].ProductID = %s, want %s", i, item.ProductID, want.ProductID)
+		}
+		if item.Quantity != want.Quantity {
+			t.Errorf("item[%d].Quantity = %d, want %d", i, item.Quantity, want.Quantity)
+		}
+	}
+}
+
+func TestMapOrderReqToDomain_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     api.OrderReqDTO
+		wantErr bool
+	}{
+		{
+			name: "missing product id",
+			req: api.OrderReqDTO{
+				Items: []api.OrderItemDTO{
+					{ProductID: "", Quantity: 1},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid quantity",
+			req: api.OrderReqDTO{
+				Items: []api.OrderItemDTO{
+					{ProductID: "p1", Quantity: 0},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty items - domain will reject",
+			req: api.OrderReqDTO{
+				Items: nil,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := api.MapOrderReqToDomain(domain.OrderID("order-1"), tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("MapOrerReqToDomain() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMapDomainProductToDTO(t *testing.T) {
+	p := domain.Product{
+		ID:       domain.ProductID("10"),
+		Name:     "Chicken Waffle",
+		Price:    domain.NewMoneyFromFloat(12.5),
+		Category: "Waffle",
+	}
+
+	dto := api.MapDomainProductToDTO(p)
+
+	if dto.ID != string(p.ID) {
+		t.Errorf("dto.ID = %s, want %s", dto.ID, p.ID)
+	}
+	if dto.Name != p.Name {
+		t.Errorf("dto.Name = %s, want %s", dto.Name, p.Name)
+	}
+	if dto.Category != p.Category {
+		t.Errorf("dto.Category = %s, want %s", dto.Category, p.Category)
+	}
+	if dto.Price != p.Price.ToFloat() {
+		t.Errorf("dto.Price = %v, want %v", dto.Price, p.Price.ToFloat())
+	}
+}
+
+func TestMapDomainOrderToDTO(t *testing.T) {
+	order := &domain.Order{
+		ID: "order-123",
+		Items: []domain.OrderItem{
+			{ProductID: "10", Quantity: 2},
+			{ProductID: "11", Quantity: 3},
+		},
+	}
+
+	products := []domain.Product{
+		{ID: "10", Name: "Chicken Waffle", Price: domain.NewMoneyFromFloat(12.0), Category: "Waffle"},
+		{ID: "11", Name: "Fries", Price: domain.NewMoneyFromFloat(5.5), Category: "Sides"},
+	}
+
+	dto := api.MapDomainOrderToDTO(order, products)
+
+	if dto.ID != string(order.ID) {
+		t.Errorf("dto.ID = %s, want %s", dto.ID, order.ID)
+	}
+
+	if len(dto.Items) != len(order.Items) {
+		t.Fatalf("dto.Items len = %d, want %d", len(dto.Items), len(order.Items))
+	}
+	for i, item := range dto.Items {
+		want := order.Items[i]
+		if item.ProductID != string(want.ProductID) {
+			t.Errorf("item[%d].ProductID = %s, want %s", i, item.ProductID, want.ProductID)
+		}
+		if item.Quantity != want.Quantity {
+			t.Errorf("item[%d].Quantity = %d, want %d", i, item.Quantity, want.Quantity)
+		}
+	}
+
+	if len(dto.Products) != len(products) {
+		t.Errorf("dto.Products len = %d, want %d", len(dto.Products), len(products))
+	}
+	for i, p := range dto.Products {
+		want := products[i]
+		if p.ID != string(want.ID) {
+			t.Errorf("products[%d].ID = %s, want %s", i, p.ID, want.ID)
+		}
+		if p.Name != want.Name {
+			t.Errorf("products[%d].Name = %s, want %s", i, p.Name, want.Name)
+		}
+		if p.Category != want.Category {
+			t.Errorf("dto.Category = %s, want %s", p.Category, want.Category)
+		}
+		if p.Price != want.Price.ToFloat() {
+			t.Errorf("dto.Price = %v, want %v", p.Price, want.Price.ToFloat())
+		}
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -1,0 +1,81 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+var (
+	ErrEmptyOrderItems   = errors.New("order must contain at least one item")
+	ErrInvalidQuantity   = errors.New("item quantity must be >=1 ")
+	ErrInvalidProductID  = errors.New("product ID must be non-empty")
+	ErrInvalidOrderID    = errors.New("order ID must be non-empty")
+	ErrInvalidCouponCode = errors.New("coupon code cannot be empty string") // if present
+)
+
+// Strongly typed IDs for clarity
+type (
+	ProductID string
+	OrderID   string
+)
+
+// Money - stored as integer cents to avoid float issues
+type Money int64
+
+func NewMoneyFromFloat(amount float64) Money {
+	return Money(math.Round(amount * 100))
+}
+
+func (m Money) ToFloat() float64 {
+	return float64(m) / 100
+}
+
+// Product is a domain representation of a purchasable item.
+type Product struct {
+	ID       ProductID
+	Name     string
+	Price    Money
+	Category string
+}
+
+// OrderItem represents a product + quantity within an order
+type OrderItem struct {
+	ProductID ProductID
+	Quantity  int
+}
+
+type Order struct {
+	ID         OrderID
+	Items      []OrderItem
+	CouponCode *string // optional
+}
+
+// NewOrder builds a valid Order an enforces basic invariants
+func NewOrder(id OrderID, items []OrderItem, couponCode *string) (*Order, error) {
+	if id == "" {
+		return nil, ErrInvalidOrderID
+	}
+	if len(items) == 0 {
+		return nil, ErrEmptyOrderItems
+	}
+
+	for i, item := range items {
+		if item.ProductID == "" {
+			return nil, fmt.Errorf("item[%d]: %w", i, ErrInvalidProductID)
+		}
+		if item.Quantity < 1 {
+			return nil, fmt.Errorf("item[%d]: %w", i, ErrInvalidQuantity)
+		}
+	}
+
+	if couponCode != nil && *couponCode == "" {
+		return nil, ErrInvalidCouponCode
+	}
+
+	return &Order{
+		ID:         id,
+		Items:      items,
+		CouponCode: couponCode,
+	}, nil
+}

--- a/internal/domain/models_test.go
+++ b/internal/domain/models_test.go
@@ -1,0 +1,145 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/M-Arthur/order-food-api/internal/domain"
+)
+
+func TestNewMoney_FromFloatAndToFloat(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    float64
+		expected domain.Money
+	}{
+		{
+			name:     "simple amount",
+			input:    12.34,
+			expected: domain.Money(1234),
+		},
+		{
+			name:     "rounding_half_up",
+			input:    1.005, // 1.005 * 100 = 100.5 -> 1010 - banker's round
+			expected: domain.Money(100),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := domain.NewMoneyFromFloat(tt.input)
+			if m != tt.expected {
+				t.Fatalf("NewMoneyFromFloat(%v) = %d, want %d", tt.input, m, tt.expected)
+			}
+
+			back := m.ToFloat()
+			if m != 0 && back == 0 {
+				t.Fatalf("ToFloat returned 0 for %v", m)
+			}
+		})
+	}
+}
+
+func TestNewOrder_Success(t *testing.T) {
+	orderID := domain.OrderID("order-123")
+	items := []domain.OrderItem{
+		{
+			ProductID: domain.ProductID("p1"),
+			Quantity:  2,
+		},
+		{
+			ProductID: domain.ProductID("p2"),
+			Quantity:  1,
+		},
+	}
+	coupon := "PROMO10"
+
+	order, err := domain.NewOrder(orderID, items, &coupon)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if order.ID != orderID {
+		t.Fatalf("order.ID = %s, want %s", order.ID, orderID)
+	}
+	if len(order.Items) != len(items) {
+		t.Fatalf("order.Items len = %d, want %d", len(order.Items), len(items))
+	}
+	if order.CouponCode == nil || *order.CouponCode != coupon {
+		t.Fatalf("order.CouponCode = %v, want %s", order.CouponCode, coupon)
+	}
+}
+
+func TestNewOrder_ValidationErors(t *testing.T) {
+	tests := []struct {
+		name      string
+		orderID   domain.OrderID
+		items     []domain.OrderItem
+		coupon    *string
+		wantError bool
+	}{
+		{
+			name:    "empty order id",
+			orderID: "",
+			items: []domain.OrderItem{
+				{ProductID: "p1", Quantity: 1},
+			},
+			wantError: true,
+		},
+		{
+			name:      "no items",
+			orderID:   "order-1",
+			items:     nil,
+			wantError: true,
+		},
+		{
+			name:    "item with empty product id",
+			orderID: "order-1",
+			items: []domain.OrderItem{
+				{ProductID: "", Quantity: 1},
+			},
+			wantError: true,
+		},
+		{
+			name:    "item with invalid quantity",
+			orderID: "order-1",
+			items: []domain.OrderItem{
+				{ProductID: "p1", Quantity: 0},
+			},
+			wantError: true,
+		},
+		{
+			name:    "empty coupon string",
+			orderID: "order-2",
+			items: []domain.OrderItem{
+				{ProductID: "p1", Quantity: 2},
+			},
+			coupon:    ptr(""),
+			wantError: true,
+		},
+		{
+			name:    "valid no coupon",
+			orderID: "order-3",
+			items: []domain.OrderItem{
+				{ProductID: "p5", Quantity: 5},
+			},
+			coupon:    nil,
+			wantError: false,
+		},
+	}
+
+	for _, ts := range tests {
+		tt := ts
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := domain.NewOrder(tt.orderID, tt.items, tt.coupon)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("NewOrder() error = %v, wantError = %v", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
This pull request introduces a new domain model and API DTO layer for products and orders, along with mapping utilities and comprehensive unit tests. The changes establish a clear separation between domain logic and API representation, enforce validation invariants, and ensure robust conversion between layers.

**Domain Model and Validation:**

- Introduced core domain types and validation logic in `models.go`, including strongly-typed IDs, a `Money` type for price handling, and robust constructors that enforce invariants for `Order` objects.

**API DTO Layer:**

- Added DTO structs in `dto.go` that map 1:1 to OpenAPI schemas for products, orders, and API responses, providing a clear contract for the API layer.

**Mapping Utilities:**

- Implemented mapping functions in `mappers.go` to convert between API DTOs and domain models, including validation of incoming requests and conversion of domain objects for API responses.

**Comprehensive Testing:**

- Added thorough unit tests for both domain logic (`models_test.go`) and mapping utilities (`mappers_test.go`), covering success and error scenarios to ensure correctness and validation enforcement. [[1]](diffhunk://#diff-e27a8eebbee48905223fbab5774008a98d1c7b95dbe904dfb06ebaeb7164f65cR1-R145) [[2]](diffhunk://#diff-3f4b8f462ac978c5f4a9177fb23a8baffd065c331ad3a59206ed5909914131eaR1-R171)