### PR TITLE
Implement in-memory product repository #4

### DIFF
--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -88,3 +88,11 @@ func NewOrder(id OrderID, items []OrderItem, couponCode *string) (*Order, error)
 		CouponCode: couponCode,
 	}, nil
 }
+
+// ProductRepository is the hexagonal port for accessing products.
+//
+// Adapters (in-memory, DB, etc.) live outside domain and implement this.
+type ProductRepository interface {
+	ListProducts() ([]Product, error)
+	GetProductByID(id ProductID) (*Product, error)
+}

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -8,21 +8,24 @@ import (
 
 var (
 	ErrEmptyOrderItems   = errors.New("order must contain at least one item")
-	ErrInvalidQuantity   = errors.New("item quantity must be >=1 ")
+	ErrInvalidQuantity   = errors.New("item quantity must be >= 1")
 	ErrInvalidProductID  = errors.New("product ID must be non-empty")
 	ErrInvalidOrderID    = errors.New("order ID must be non-empty")
 	ErrInvalidCouponCode = errors.New("coupon code cannot be empty string") // if present
+
+	ErrProductNotFound = errors.New("product not found")
 )
 
-// Strongly typed IDs for clarity
+// Strongly typed IDs for clarity and type safety.
 type (
 	ProductID string
 	OrderID   string
 )
 
-// Money - stored as integer cents to avoid float issues
+// Money represents currency in integer cents to avoid float issues.
 type Money int64
 
+// NewMoneyFromFloat creates Money from a float, rounding to the nearest cent.
 func NewMoneyFromFloat(amount float64) Money {
 	return Money(math.Round(amount * 100))
 }
@@ -39,19 +42,22 @@ type Product struct {
 	Category string
 }
 
-// OrderItem represents a product + quantity within an order
+// OrderItem represents a product + quantity within an order.
 type OrderItem struct {
 	ProductID ProductID
 	Quantity  int
 }
 
+// Order is a domain aggregate for a placed order.
 type Order struct {
 	ID         OrderID
 	Items      []OrderItem
 	CouponCode *string // optional
 }
 
-// NewOrder builds a valid Order an enforces basic invariants
+// NewOrder builds a valid Order and enforces basic invariants.
+//
+// It defensively copies the items slice so callers cannot mutate internal state.
 func NewOrder(id OrderID, items []OrderItem, couponCode *string) (*Order, error) {
 	if id == "" {
 		return nil, ErrInvalidOrderID
@@ -73,9 +79,12 @@ func NewOrder(id OrderID, items []OrderItem, couponCode *string) (*Order, error)
 		return nil, ErrInvalidCouponCode
 	}
 
+	itemsCopy := make([]OrderItem, len(items))
+	copy(itemsCopy, items)
+
 	return &Order{
 		ID:         id,
-		Items:      items,
+		Items:      itemsCopy,
 		CouponCode: couponCode,
 	}, nil
 }

--- a/internal/storage/inmemory_product_repository.go
+++ b/internal/storage/inmemory_product_repository.go
@@ -1,0 +1,38 @@
+package storage
+
+import "github.com/M-Arthur/order-food-api/internal/domain"
+
+// InMemoryProductRepository is an adapter implementing domain.ProductRepository.
+//
+// It is read-only after construction and is safe for concurrent access.
+type InMemoryProductRepository struct {
+	products map[domain.ProductID]domain.Product
+}
+
+func NewInMemoryProductRepository(seed []domain.Product) domain.ProductRepository {
+	m := make(map[domain.ProductID]domain.Product)
+	for _, p := range seed {
+		m[p.ID] = p
+	}
+	return &InMemoryProductRepository{
+		products: m,
+	}
+}
+
+func (r *InMemoryProductRepository) ListProducts() ([]domain.Product, error) {
+	out := make([]domain.Product, 0, len(r.products))
+	for _, p := range r.products {
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+func (r *InMemoryProductRepository) GetProductByID(id domain.ProductID) (*domain.Product, error) {
+	p, ok := r.products[id]
+	if !ok {
+		return nil, domain.ErrProductNotFound
+	}
+
+	cp := p // copy to avoid mutation of internal state
+	return &cp, nil
+}

--- a/internal/storage/inmemory_product_repository_test.go
+++ b/internal/storage/inmemory_product_repository_test.go
@@ -1,0 +1,65 @@
+package storage_test
+
+import (
+	"testing"
+
+	"github.com/M-Arthur/order-food-api/internal/domain"
+	"github.com/M-Arthur/order-food-api/internal/storage"
+)
+
+func TestInMemoryProductRepository_GetProductByID(t *testing.T) {
+	repo := storage.NewInMemoryProductRepository([]domain.Product{
+		{ID: "10", Name: "Chicken Waffle", Price: domain.NewMoneyFromFloat(12.5), Category: "Waffle"},
+	})
+
+	tests := []struct {
+		name    string
+		id      domain.ProductID
+		wantErr bool
+	}{
+		{name: "found", id: "10", wantErr: false},
+		{name: "not found", id: "999", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := repo.GetProductByID(tt.id)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if p != nil {
+					t.Fatalf("expected nil product, got %+v", p)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if p == nil {
+				t.Fatalf("expected product, got nill")
+			}
+			if p.ID != "10" {
+				t.Fatalf("expected ID=%s, got %s", "10", p.ID)
+			}
+		})
+	}
+}
+
+func TestInMemoryProductRepository_ListProducts(t *testing.T) {
+	repo := storage.NewInMemoryProductRepository([]domain.Product{
+		{ID: "10", Name: "Chicken Waffle", Price: domain.NewMoneyFromFloat(12.5), Category: "Waffle"},
+		{ID: "11", Name: "Vegan Waffle", Price: domain.NewMoneyFromFloat(11.0), Category: "Waffle"},
+	})
+
+	list, err := repo.ListProducts()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := len(list); got != 2 {
+		t.Fatalf("expected 2 products, got %d", got)
+	}
+}


### PR DESCRIPTION
This pull request introduces several improvements and new features to the order-food API, focusing on better validation, defensive programming, and the introduction of a hexagonal port for product data access. It also adds an in-memory product repository adapter and comprehensive tests for both new and existing functionality.

**Validation and Error Handling Improvements:**

- Added a new `ValidationError` type in `internal/api/mappers.go` for API-level field-specific validation errors, replacing generic errors and enabling more precise error reporting in the API layer. Validation now occurs for each order item and returns the specific field and message when invalid.
- Updated tests in `internal/api/mappers_test.go` to check for the new `ValidationError` type, including field and message, and to distinguish between adapter-level and domain-level validation errors. [[1]](diffhunk://#diff-3f4b8f462ac978c5f4a9177fb23a8baffd065c331ad3a59206ed5909914131eaR55-R57) [[2]](diffhunk://#diff-3f4b8f462ac978c5f4a9177fb23a8baffd065c331ad3a59206ed5909914131eaR67-R68) [[3]](diffhunk://#diff-3f4b8f462ac978c5f4a9177fb23a8baffd065c331ad3a59206ed5909914131eaR78-R122)

**Domain Model Enhancements:**

- Updated `NewOrder` in `internal/domain/models.go` to defensively copy the `items` slice, preventing external mutation of the order's items after creation. [[1]](diffhunk://#diff-1dd27e0d29106ef51cbf9571800808ec21b5b50d0ea6b5c0f18a4d66696cf3cbL42-R60) [[2]](diffhunk://#diff-1dd27e0d29106ef51cbf9571800808ec21b5b50d0ea6b5c0f18a4d66696cf3cbR82-R98)
- Added a new interface `ProductRepository` to the domain layer, establishing a hexagonal port for product data access, to be implemented by adapters such as in-memory or database repositories.
- Introduced a new domain error `ErrProductNotFound` for missing products.

**Adapters and Testing:**

- Added a new `InMemoryProductRepository` adapter in `internal/storage/inmemory_product_repository.go`, implementing the `ProductRepository` interface, with methods for listing products and retrieving by ID. The repository is read-only after construction and safe for concurrent use.
- Added comprehensive tests for `InMemoryProductRepository` in `internal/storage/inmemory_product_repository_test.go`, covering both retrieval and listing of products.

**Test Improvements and Refactoring:**

- Improved test coverage and clarity in `internal/domain/models_test.go`, including checks that `NewOrder` performs a defensive copy of items and improved Money round-trip float conversion testing. [[1]](diffhunk://#diff-e27a8eebbee48905223fbab5774008a98d1c7b95dbe904dfb06ebaeb7164f65cL21-R39) [[2]](diffhunk://#diff-e27a8eebbee48905223fbab5774008a98d1c7b95dbe904dfb06ebaeb7164f65cR73-R81)
- Fixed typos and improved error messages in various tests for better diagnostics. [[1]](diffhunk://#diff-3f4b8f462ac978c5f4a9177fb23a8baffd065c331ad3a59206ed5909914131eaR4-R11) [[2]](diffhunk://#diff-3f4b8f462ac978c5f4a9177fb23a8baffd065c331ad3a59206ed5909914131eaL161-R200)

These changes collectively enhance the robustness, maintainability, and extensibility of the codebase, especially in terms of error handling, domain modeling, and testability.