### PR TITLE
Implement GET /product/{productId} #6

### DIFF
--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -94,5 +94,10 @@ func NewOrder(id OrderID, items []OrderItem, couponCode *string) (*Order, error)
 // Adapters (in-memory, DB, etc.) live outside domain and implement this.
 type ProductRepository interface {
 	ListProducts() ([]Product, error)
+
+	// GetProductByID returns the product base on given ID
+	//
+	// domain.ErrProductNotFound should be returned when no product can be found
+	// based on the given ID
 	GetProductByID(id ProductID) (*Product, error)
 }

--- a/internal/httpapi/handlers/product_handler.go
+++ b/internal/httpapi/handlers/product_handler.go
@@ -1,24 +1,26 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/M-Arthur/order-food-api/internal/api"
+	"github.com/M-Arthur/order-food-api/internal/domain"
 	"github.com/M-Arthur/order-food-api/internal/httpapi/shared"
 	"github.com/M-Arthur/order-food-api/internal/service"
+	"github.com/go-chi/chi"
 	"github.com/rs/zerolog"
 )
 
 // ProductHandler is the HTTP adapter for product-related endpoints.
 type ProductHandler struct {
 	productSvc service.ProductService
-	logger     zerolog.Logger
 }
 
-func NewProductHandler(productSvc service.ProductService, l zerolog.Logger) *ProductHandler {
+func NewProductHandler(productSvc service.ProductService) *ProductHandler {
 	return &ProductHandler{
 		productSvc: productSvc,
-		logger:     l,
 	}
 }
 
@@ -35,5 +37,40 @@ func (h *ProductHandler) ListProducts(w http.ResponseWriter, r *http.Request) {
 	}
 
 	dto := api.MapDomainProductsToDTO(products)
+	shared.WriteJSON(w, r, http.StatusOK, dto)
+}
+
+// GetProductByID handles GET /product/{productId}
+func (h *ProductHandler) GetProductByID(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	logger := zerolog.Ctx(ctx)
+
+	idStr := chi.URLParam(r, "productId")
+	if idStr == "" {
+		shared.WriteJSONError(w, r, http.StatusBadRequest, "Invalid ID supplied")
+		return
+	}
+
+	// per OpenAPI: productId is int64
+	if _, err := strconv.ParseInt(idStr, 10, 64); err != nil {
+		logger.Warn().Str("productId", idStr).Err(err).Msg("invalid product ID format")
+		shared.WriteJSONError(w, r, http.StatusBadRequest, "invalid ID supplied")
+		return
+	}
+
+	product, err := h.productSvc.GetProduct(ctx, domain.ProductID(idStr))
+	if errors.Is(err, domain.ErrProductNotFound) {
+		logger.Warn().Str("productId", idStr).Msg("product not found")
+		shared.WriteJSONError(w, r, http.StatusNotFound, "Product not found")
+		return
+	}
+	if err != nil {
+		logger.Error().Str("productId", idStr).Err(err).Msg("product not found")
+		// It should return 500 HTTP status code in PROD
+		shared.WriteJSONError(w, r, http.StatusNotFound, "Product not found")
+		return
+	}
+
+	dto := api.MapDomainProductToDTO(*product)
 	shared.WriteJSON(w, r, http.StatusOK, dto)
 }

--- a/internal/httpapi/handlers/product_handler_test.go
+++ b/internal/httpapi/handlers/product_handler_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,17 +14,41 @@ import (
 	"github.com/M-Arthur/order-food-api/internal/domain"
 	"github.com/M-Arthur/order-food-api/internal/httpapi/handlers"
 	"github.com/M-Arthur/order-food-api/internal/service"
+	"github.com/go-chi/chi"
 	"github.com/rs/zerolog"
 )
 
 // stubProductService implemnets service.ProductService for tests
 type stubProductService struct {
-	products []domain.Product
+	products map[domain.ProductID]domain.Product
 	err      error
 }
 
+func newStubProductService(seed []domain.Product, err error) *stubProductService {
+	products := make(map[domain.ProductID]domain.Product)
+	for _, p := range seed {
+		products[p.ID] = p
+	}
+	return &stubProductService{
+		products: products,
+		err:      err,
+	}
+}
+
 func (s *stubProductService) ListProducts(_ context.Context) ([]domain.Product, error) {
-	return s.products, s.err
+	out := make([]domain.Product, 0, len(s.products))
+	for _, p := range s.products {
+		out = append(out, p)
+	}
+	return out, s.err
+}
+
+func (s *stubProductService) GetProduct(_ context.Context, id domain.ProductID) (*domain.Product, error) {
+	p, ok := s.products[id]
+	if !ok {
+		return nil, domain.ErrProductNotFound
+	}
+	return &p, s.err
 }
 
 // Ensure stub implements the interface at complie time
@@ -36,10 +59,9 @@ func TestProductHandler_ListProducts_Success(t *testing.T) {
 		{ID: domain.ProductID("10"), Name: "Chicken Waffle", Price: domain.NewMoneyFromFloat(12.5), Category: "Waffle"},
 		{ID: domain.ProductID("11"), Name: "Fries", Price: domain.NewMoneyFromFloat(5.5), Category: "Sides"},
 	}
-	baseLogger := zerolog.New(io.Discard).With().Timestamp().Logger()
 
-	svc := &stubProductService{products: seed}
-	h := handlers.NewProductHandler(svc, baseLogger)
+	svc := newStubProductService(seed, nil)
+	h := handlers.NewProductHandler(svc)
 
 	req := httptest.NewRequest(http.MethodGet, "/product", nil)
 	rr := httptest.NewRecorder()
@@ -94,8 +116,8 @@ func TestProductHandler_ListProducts_Error(t *testing.T) {
 	baseLogger := zerolog.New(&buf).With().Timestamp().Logger()
 	zerolog.DefaultContextLogger = &baseLogger
 
-	svc := &stubProductService{products: seed, err: errors.New("test error")}
-	h := handlers.NewProductHandler(svc, baseLogger)
+	svc := newStubProductService(seed, errors.New("test error"))
+	h := handlers.NewProductHandler(svc)
 
 	req := httptest.NewRequest(http.MethodGet, "/product", nil)
 	rr := httptest.NewRecorder()
@@ -112,5 +134,74 @@ func TestProductHandler_ListProducts_Error(t *testing.T) {
 	}
 	if !strings.Contains(logOutput, "test error") {
 		t.Fatalf("expected 'test error' in log output, got: %s", logOutput)
+	}
+}
+
+func TestProductHandler_GetProduct_Success(t *testing.T) {
+	seed := []domain.Product{
+		{ID: domain.ProductID("10"), Name: "Chicken Waffle", Price: domain.NewMoneyFromFloat(12.5), Category: "Waffle"},
+		{ID: domain.ProductID("11"), Name: "Fries", Price: domain.NewMoneyFromFloat(5.5), Category: "Sides"},
+	}
+
+	svc := newStubProductService(seed, nil)
+	h := handlers.NewProductHandler(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/product/10", nil)
+	rr := httptest.NewRecorder()
+
+	// Simulate chi param extraction
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("productId", "10")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	h.GetProductByID(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var got api.ProductDTO
+	if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+
+	if got.ID != "10" {
+		t.Fatalf("got.ID = %s, want 10", got.ID)
+	}
+}
+
+func TestProductHandler_GetProduct_Error(t *testing.T) {
+	seed := []domain.Product{
+		{ID: domain.ProductID("10"), Name: "Chicken Waffle", Price: domain.NewMoneyFromFloat(12.5), Category: "Waffle"},
+	}
+
+	svc := newStubProductService(seed, nil)
+	h := handlers.NewProductHandler(svc)
+
+	tests := []struct {
+		name string
+		id   string
+		code int
+	}{
+		{name: "invalid id format", id: "abc", code: http.StatusBadRequest},
+		{name: "not found", id: "999", code: http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/product/"+tt.id, nil)
+			rr := httptest.NewRecorder()
+
+			// Simulate chi param extraction
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("productId", tt.id)
+			req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+			h.GetProductByID(rr, req)
+
+			if rr.Code != tt.code {
+				t.Fatalf("status = %d, want %d", rr.Code, tt.code)
+			}
+		})
 	}
 }

--- a/internal/httpapi/router.go
+++ b/internal/httpapi/router.go
@@ -31,7 +31,7 @@ func NewRouter(cfg RouterConfig) http.Handler {
 
 	// --- Route groups / endpoints ---
 	registerHealthRoutes(r)
-	registerProductRoutes(r, cfg.Logger)
+	registerProductRoutes(r)
 
 	return r
 }
@@ -41,14 +41,15 @@ func registerHealthRoutes(r chi.Router) {
 	r.Get("/health", handlers.Health)
 }
 
-func registerProductRoutes(r chi.Router, l zerolog.Logger) {
+func registerProductRoutes(r chi.Router) {
 	seedProducts := []domain.Product{
 		{ID: domain.ProductID("10"), Name: "Chicken Waffle", Price: domain.NewMoneyFromFloat(12.5), Category: "Waffle"},
 		{ID: domain.ProductID("11"), Name: "Fries", Price: domain.NewMoneyFromFloat(5.5), Category: "Sides"},
 	}
 	productRepo := storage.NewInMemoryProductRepository(seedProducts)
 	productSvc := service.NewProductService(productRepo)
-	productHandler := handlers.NewProductHandler(productSvc, l)
+	productHandler := handlers.NewProductHandler(productSvc)
 
 	r.Get("/product", productHandler.ListProducts)
+	r.Get("/product/{productId}", productHandler.GetProductByID)
 }

--- a/internal/service/product_service.go
+++ b/internal/service/product_service.go
@@ -9,6 +9,7 @@ import (
 // ProductService defines application-level operations for products.
 type ProductService interface {
 	ListProducts(ctx context.Context) ([]domain.Product, error)
+	GetProduct(ctx context.Context, id domain.ProductID) (*domain.Product, error)
 }
 
 type productService struct {
@@ -24,4 +25,8 @@ func NewProductService(repo domain.ProductRepository) ProductService {
 func (s *productService) ListProducts(ctx context.Context) ([]domain.Product, error) {
 	// Business logic would go here in future (filtering, sorting, etc.)
 	return s.repo.ListProducts()
+}
+
+func (s *productService) GetProduct(ctx context.Context, id domain.ProductID) (*domain.Product, error) {
+	return s.repo.GetProductByID(id)
 }


### PR DESCRIPTION
This pull request adds support for fetching a single product by its ID via a new HTTP endpoint, along with corresponding service and repository methods. It also introduces comprehensive tests for the new functionality and refactors some code for improved testability and clarity.

**API and Handler Enhancements:**

* Added a new HTTP endpoint `GET /product/{productId}` handled by `ProductHandler.GetProductByID`, which retrieves a product by its ID and returns appropriate error responses for invalid or non-existent IDs. [[1]](diffhunk://#diff-95575b47dd317de03d26a5bae234ed0f9355bb0a642c1c8ae76f3983e399ba90R42-R76) [[2]](diffhunk://#diff-89b5a3f1a5bdb278e6e6b681ea52a24ce3e707eca6966b333264ba8e6110721aL44-R54)
* Updated the product handler and router setup to remove unnecessary logger dependencies, simplifying handler construction and registration. [[1]](diffhunk://#diff-95575b47dd317de03d26a5bae234ed0f9355bb0a642c1c8ae76f3983e399ba90R4-L21) [[2]](diffhunk://#diff-89b5a3f1a5bdb278e6e6b681ea52a24ce3e707eca6966b333264ba8e6110721aL34-R34) [[3]](diffhunk://#diff-89b5a3f1a5bdb278e6e6b681ea52a24ce3e707eca6966b333264ba8e6110721aL44-R54)

**Service and Domain Layer Updates:**

* Extended the `ProductService` interface and implementation with a `GetProduct` method for fetching a product by ID, delegating to the repository. [[1]](diffhunk://#diff-0c4e56666670c685178da6128f84c0c9e98d7f9ff7743fc8fa32d3fbc7cf74fdR12) [[2]](diffhunk://#diff-0c4e56666670c685178da6128f84c0c9e98d7f9ff7743fc8fa32d3fbc7cf74fdR29-R32)
* Clarified the contract for `ProductRepository.GetProductByID` in the domain model, specifying the expected error for not found cases.

**Testing Improvements:**

* Refactored the product service test stub to use a map for efficient lookup and added tests for the new `GetProductByID` handler, covering success, invalid ID, and not found scenarios. [[1]](diffhunk://#diff-24b2d9b69767ab69cd422fb0ace5fc5de56e968d77d6eddddfbf55741cb5a309R17-R51) [[2]](diffhunk://#diff-24b2d9b69767ab69cd422fb0ace5fc5de56e968d77d6eddddfbf55741cb5a309L39-R64) [[3]](diffhunk://#diff-24b2d9b69767ab69cd422fb0ace5fc5de56e968d77d6eddddfbf55741cb5a309R139-R207)
* Updated existing tests to use the new stub constructor and removed unnecessary logger setup. [[1]](diffhunk://#diff-24b2d9b69767ab69cd422fb0ace5fc5de56e968d77d6eddddfbf55741cb5a309L39-R64) [[2]](diffhunk://#diff-24b2d9b69767ab69cd422fb0ace5fc5de56e968d77d6eddddfbf55741cb5a309L97-R120)